### PR TITLE
Support url query that is not HTML query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Ideally, the Java SDK would provide a good way to build properly encoded URLs. U
 
 URL encoding is also not something that can be done once you've formed a complete URL string. If your URL is already correctly encoded, you do not need to do anything. If it is not, it is impossible to parse it into its constituent parts for subsequent encoding. You must construct a url piece by piece, correctly encoding each piece as you go, to end up with a valid URL string. The encoding rules are also different for different parts of the URL (path, query param, etc.)
 
- Since the URLs that we use in practice for HTTP have somewhat different rules than "generic" URLs, UrlBuilder errs on the side of usefulness for HTTP-specific URLs. Notably, this means that '+' is percent-encoded to avoid being interpreted as a space.
+ Since the URLs that we use in practice for HTTP have somewhat different rules than "generic" URLs, UrlBuilder errs on the side of usefulness for HTTP-specific URLs. Notably, this means that '+' is percent-encoded to avoid being interpreted as a space. Also, in the URL/URI specs, the query string's format is not defined, but in practice it is used to hold `key=value` pairs separated by `&`.
 
  # Building
 
- Run `gradle build`. To see coverage, run `gradle cobertura` and look in `build/reports/cobertura/index.html`.
+ Run `./gradlew build`.

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
   jmh "org.openjdk.jmh:jmh-core:${depVersions.jmh}"
   jmh "org.openjdk.jmh:jmh-generator-annprocess:${depVersions.jmh}"
+  compile "org.openjdk.jmh:jmh-core:$depVersions.jmh"
 }
 
 repositories {

--- a/src/jmh/java/com/palominolabs/http/url/PercentDecoderBenchmark.java
+++ b/src/jmh/java/com/palominolabs/http/url/PercentDecoderBenchmark.java
@@ -17,7 +17,7 @@ public class PercentDecoderBenchmark {
     static final String LARGE_STRING_ENCODED;
 
     static {
-        PercentEncoder encoder = UrlPercentEncoders.getQueryEncoder();
+        PercentEncoder encoder = UrlPercentEncoders.getUnstructuredQueryEncoder();
         try {
             SMALL_STRING_ENCODED = encoder.encode(SMALL_STRING_MIX);
         } catch (CharacterCodingException e) {

--- a/src/jmh/java/com/palominolabs/http/url/PercentEncoderBenchmark.java
+++ b/src/jmh/java/com/palominolabs/http/url/PercentEncoderBenchmark.java
@@ -29,7 +29,7 @@ public class PercentEncoderBenchmark {
 
     @State(Scope.Thread)
     public static class ThreadState {
-        PercentEncoder encoder = UrlPercentEncoders.getQueryEncoder();
+        PercentEncoder encoder = UrlPercentEncoders.getUnstructuredQueryEncoder();
         PercentEncoderOutputHandler noOpHandler = new NoOpOutputHandler();
         AccumXorOutputHandler accumXorHandler = new AccumXorOutputHandler();
     }

--- a/src/main/java/com/palominolabs/http/url/UrlBuilder.java
+++ b/src/main/java/com/palominolabs/http/url/UrlBuilder.java
@@ -133,14 +133,14 @@ public final class UrlBuilder {
     /**
      * Create a UrlBuilder initialized with the contents of a {@link URL}.
      *
-     * The query string will be parsed into HTML4 query params if it can be separated into a <code>&amp;</code>-separated
-     * sequence of <code>key=value</code> pairs. The sequence of query params can then be appended to by continuing to
-     * call {@link UrlBuilder#queryParam(String, String)}. The concept of query params is only part of the HTML spec
-     * (and common HTTP usage), though, so it's perfectly legal to have a query string that is in some other form. To
-     * represent this case, if the aforementioned param-parsing attempt fails, the query string will be treated as just
-     * a monolithic, unstructured, string. In this case, calls to {@link UrlBuilder#queryParam(String, String)} on the
-     * resulting instance will throw IllegalStateException, and only calls to {@link UrlBuilder#query(String)}}, which
-     * replaces the entire query string, are allowed.
+     * The query string will be parsed into HTML4 query params if it can be separated into a
+     * <code>&amp;</code>-separated sequence of <code>key=value</code> pairs. The sequence of query params can then be
+     * appended to by continuing to call {@link UrlBuilder#queryParam(String, String)}. The concept of query params is
+     * only part of the HTML spec (and common HTTP usage), though, so it's perfectly legal to have a query string that
+     * is in some other form. To represent this case, if the aforementioned param-parsing attempt fails, the query
+     * string will be treated as just a monolithic, unstructured, string. In this case, calls to {@link
+     * UrlBuilder#queryParam(String, String)} on the resulting instance will throw IllegalStateException, and only calls
+     * to {@link UrlBuilder#query(String)}}, which replaces the entire query string, are allowed.
      *
      * @param url            url to initialize builder with
      * @param charsetDecoder the decoder to decode encoded bytes with (except for reg names, which are always UTF-8)
@@ -233,8 +233,8 @@ public final class UrlBuilder {
     }
 
     /**
-     * Add a complete query string of arbitrary structure. This is useful when you want to specify a query string that
-     * is not of key=value format.
+     * Add a complete query string of arbitrary structure, replacing any previously set query. This is useful when you
+     * want to specify a query string that is not of key=value format.
      *
      * If you use this method, you cannot also use {@link UrlBuilder#queryParam(String, String)}. See {@link
      * UrlBuilder#fromUrl(URL, CharsetDecoder)}.
@@ -367,8 +367,6 @@ public final class UrlBuilder {
         CharacterCodingException {
         if (url.getQuery() != null) {
             String q = url.getQuery();
-
-            // TODO: parse into query param name=value pairs if possible, but if not, just have an unstructured 'query'
 
             // try to parse into &-separated key=value pairs
             List<Pair<String, String>> pairs = new ArrayList<Pair<String, String>>();

--- a/src/main/java/com/palominolabs/http/url/UrlBuilder.java
+++ b/src/main/java/com/palominolabs/http/url/UrlBuilder.java
@@ -208,7 +208,7 @@ public final class UrlBuilder {
     }
 
     /**
-     * Add a query parameter. Query parameters will be encoded in the order added.
+     * Add an HTML query parameter. Query parameters will be encoded in the order added.
      *
      * Using query strings to encode key=value pairs is not part of the URI/URL specification; it is specified by
      * http://www.w3.org/TR/html401/interact/forms.html#form-content-type.
@@ -233,7 +233,7 @@ public final class UrlBuilder {
     }
 
     /**
-     * Add a complete query string of arbitrary structure, replacing any previously set query. This is useful when you
+     * Set the complete query string of arbitrary structure, replacing any previously set query. This is useful when you
      * want to specify a query string that is not of key=value format.
      *
      * If you use this method, you cannot also use {@link UrlBuilder#queryParam(String, String)}. See {@link
@@ -380,7 +380,8 @@ public final class UrlBuilder {
                     break;
                 }
 
-                pairs.add(Pair.of(decoder.decode(queryParamChunks[0]), decoder.decode(queryParamChunks[1])));
+                pairs.add(Pair.of(decoder.decode(queryParamChunks[0]),
+                    decoder.decode(queryParamChunks[1])));
             }
 
             if (parseOk) {
@@ -388,7 +389,7 @@ public final class UrlBuilder {
                     builder.queryParam(pair.getKey(), pair.getValue());
                 }
             } else {
-                builder.query(q);
+                builder.query(decoder.decode(q));
             }
         }
     }

--- a/src/main/java/com/palominolabs/http/url/UrlPercentEncoders.java
+++ b/src/main/java/com/palominolabs/http/url/UrlPercentEncoders.java
@@ -43,51 +43,52 @@ public final class UrlPercentEncoders {
         MATRIX_BIT_SET.clear((int) ';');
         MATRIX_BIT_SET.clear((int) '=');
 
-        // at this point it represents RFC 3986 'query'.
+        /*
+         * At this point it represents RFC 3986 'query'. http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1 also
+         * specifies that "+" can mean space in a query, so we will make sure to say that '+' is not safe to leave as-is
+         */
         addQuery(UNSTRUCTURED_QUERY_BIT_SET);
-
+        UNSTRUCTURED_QUERY_BIT_SET.clear((int) '+');
 
         /*
-         * Create more stringent requirements for HTML4 queries: remove delimiters for HTML queries so that key=value
-         * pairs can be used. http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1 also specifies that "+" can
-         * mean space in a query, so we will make sure to say that '+' is not safe to leave as-is
+         * Create more stringent requirements for HTML4 queries: remove delimiters for HTML query params so that key=value
+         * pairs can be used.
          */
         QUERY_PARAM_BIT_SET.or(UNSTRUCTURED_QUERY_BIT_SET);
         QUERY_PARAM_BIT_SET.clear((int) '=');
         QUERY_PARAM_BIT_SET.clear((int) '&');
-        QUERY_PARAM_BIT_SET.clear((int) '+');
 
         addFragment(FRAGMENT_BIT_SET);
     }
 
     public static PercentEncoder getRegNameEncoder() {
         return new PercentEncoder(REG_NAME_BIT_SET, UTF_8.newEncoder().onMalformedInput(REPLACE)
-            .onUnmappableCharacter(REPLACE));
+                .onUnmappableCharacter(REPLACE));
     }
 
     public static PercentEncoder getPathEncoder() {
         return new PercentEncoder(PATH_BIT_SET, UTF_8.newEncoder().onMalformedInput(REPLACE)
-            .onUnmappableCharacter(REPLACE));
+                .onUnmappableCharacter(REPLACE));
     }
 
     public static PercentEncoder getMatrixEncoder() {
         return new PercentEncoder(MATRIX_BIT_SET, UTF_8.newEncoder().onMalformedInput(REPLACE)
-            .onUnmappableCharacter(REPLACE));
+                .onUnmappableCharacter(REPLACE));
     }
 
     public static PercentEncoder getUnstructuredQueryEncoder() {
         return new PercentEncoder(UNSTRUCTURED_QUERY_BIT_SET, UTF_8.newEncoder().onMalformedInput(REPLACE)
-            .onUnmappableCharacter(REPLACE));
+                .onUnmappableCharacter(REPLACE));
     }
 
     public static PercentEncoder getQueryParamEncoder() {
         return new PercentEncoder(QUERY_PARAM_BIT_SET, UTF_8.newEncoder().onMalformedInput(REPLACE)
-            .onUnmappableCharacter(REPLACE));
+                .onUnmappableCharacter(REPLACE));
     }
 
     public static PercentEncoder getFragmentEncoder() {
         return new PercentEncoder(FRAGMENT_BIT_SET, UTF_8.newEncoder().onMalformedInput(REPLACE)
-            .onUnmappableCharacter(REPLACE));
+                .onUnmappableCharacter(REPLACE));
     }
 
     private UrlPercentEncoders() {

--- a/src/main/java/com/palominolabs/http/url/UrlPercentEncoders.java
+++ b/src/main/java/com/palominolabs/http/url/UrlPercentEncoders.java
@@ -44,7 +44,7 @@ public final class UrlPercentEncoders {
 
         /*
         * at this point it represents RFC 3986 'query'.
-        * Remove delimiters for HTTP queries
+        * Remove delimiters for HTML queries
         * http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1 also specifies that "+" can mean space in a query,
         * so we will make sure to say that '+' is not safe to leave as-is
         */

--- a/src/test/groovy/com/palominolabs/http/url/PercentDecoderTest.groovy
+++ b/src/test/groovy/com/palominolabs/http/url/PercentDecoderTest.groovy
@@ -63,7 +63,7 @@ class PercentDecoderTest {
   @Test
   @CompileStatic
   public void testRandomStrings() {
-    PercentEncoder encoder = UrlPercentEncoders.getQueryEncoder()
+    PercentEncoder encoder = UrlPercentEncoders.getUnstructuredQueryEncoder()
     Random rand = new Random()
 
     def seed = rand.nextLong()

--- a/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
+++ b/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
@@ -5,13 +5,12 @@
 package com.palominolabs.http.url;
 
 import com.google.common.base.Throwables;
-import org.junit.Test;
-
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.CharacterCodingException;
+import org.junit.Test;
 
 import static com.palominolabs.http.url.UrlBuilder.forHost;
 import static com.palominolabs.http.url.UrlBuilder.fromUrl;
@@ -317,13 +316,28 @@ public final class UrlBuilderTest {
     }
 
     @Test
-    public void testFromUrlMalformedQueryParam() throws MalformedURLException, CharacterCodingException {
-        try {
-            fromUrl(new URL("http://foo.com/foo?q1=v1=v2"));
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals("Malformed query param: <q1=v1=v2>", e.getMessage());
-        }
+    public void testFromUrlMalformedQueryParamMultiValues() throws MalformedURLException, CharacterCodingException {
+        assertUrlBuilderRoundtrip("http://foo.com/foo?q1=v1=v2");
+    }
+
+    @Test
+    public void testFromUrlUnstructuredQuery() throws MalformedURLException, CharacterCodingException {
+        assertUrlBuilderRoundtrip("http://foo.com/foo?query");
+    }
+
+    @Test
+    public void testCantUseQueryParamAfterQuery() {
+
+    }
+
+    @Test
+    public void testCantUseQueryAfterQueryParam() {
+
+    }
+
+    @Test
+    public void testQueryWithSpecialChars() {
+
     }
 
     private void assertUrlBuilderRoundtrip(String url) {

--- a/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
+++ b/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
@@ -61,10 +61,10 @@ public final class UrlBuilderTest {
     @Test
     public void testMatrixWithReserved() throws CharacterCodingException {
         UrlBuilder ub = forHost("http", "foo.com")
-            .pathSegment("foo")
-            .matrixParam("foo", "bar")
-            .matrixParam("res;=?#/erved", "value")
-            .pathSegment("baz");
+                .pathSegment("foo")
+                .matrixParam("foo", "bar")
+                .matrixParam("res;=?#/erved", "value")
+                .pathSegment("baz");
         assertUrlEquals("http://foo.com/foo;foo=bar;res%3B%3D%3F%23%2Ferved=value/baz", ub.toUrlString());
     }
 
@@ -123,9 +123,9 @@ public final class UrlBuilderTest {
         UrlBuilder ub = forHost("http", "foo.com");
 
         ub.pathSegment("has+plus")
-            .matrixParam("plusMtx", "pl+us")
-            .queryParam("plusQp", "pl+us")
-            .fragment("plus+frag");
+                .matrixParam("plusMtx", "pl+us")
+                .queryParam("plusQp", "pl+us")
+                .fragment("plus+frag");
 
         assertUrlEquals("http://foo.com/has+plus;plusMtx=pl+us?plusQp=pl%2Bus#plus+frag", ub.toUrlString());
     }
@@ -150,7 +150,7 @@ public final class UrlBuilderTest {
         ub.fragment("zomg it's a fragment");
 
         assertEquals("https://foo.bar.com:3333/foo/bar;mtx1=val1;mtx2=val2?q1=v1&q2=v2#zomg%20it's%20a%20fragment",
-            ub.toUrlString());
+                ub.toUrlString());
     }
 
     @Test
@@ -199,7 +199,7 @@ public final class UrlBuilderTest {
     @Test
     public void testForceTrailingSlashWithQueryParams() throws CharacterCodingException {
         UrlBuilder ub =
-            forHost("https", "foo.com").forceTrailingSlash().pathSegments("a", "b", "c").queryParam("foo", "bar");
+                forHost("https", "foo.com").forceTrailingSlash().pathSegments("a", "b", "c").queryParam("foo", "bar");
 
         assertUrlEquals("https://foo.com/a/b/c/?foo=bar", ub.toUrlString());
     }
@@ -215,10 +215,10 @@ public final class UrlBuilderTest {
     public void testIntermingledMatrixParamsAndPathSegments() throws CharacterCodingException {
 
         UrlBuilder ub = forHost("http", "foo.com")
-            .pathSegments("seg1", "seg2")
-            .matrixParam("m1", "v1")
-            .pathSegment("seg3")
-            .matrixParam("m2", "v2");
+                .pathSegments("seg1", "seg2")
+                .matrixParam("m1", "v1")
+                .pathSegment("seg3")
+                .matrixParam("m2", "v2");
 
         assertUrlEquals("http://foo.com/seg1/seg2;m1=v1/seg3;m2=v2", ub.toUrlString());
     }
@@ -226,7 +226,7 @@ public final class UrlBuilderTest {
     @Test
     public void testFromUrlWithEverything() {
         String orig =
-            "https://foo.bar.com:3333/foo/ba%20r;mtx1=val1;mtx2=val%202/seg%203;m2=v2?q1=v1&q2=v%202#zomg%20it's%20a%20fragment";
+                "https://foo.bar.com:3333/foo/ba%20r;mtx1=val1;mtx2=val%202/seg%203;m2=v2?q1=v1&q2=v%202#zomg%20it's%20a%20fragment";
         assertUrlBuilderRoundtrip(orig);
     }
 
@@ -337,14 +337,14 @@ public final class UrlBuilderTest {
 
     @Test
     public void testCantUseQueryParamAfterQuery() {
-        UrlBuilder ub = forHost("http", "foo.com").query("q");
+        UrlBuilder ub = forHost("http", "foo.com").unstructuredQuery("q");
 
         try {
             ub.queryParam("foo", "bar");
             fail();
         } catch (IllegalStateException e) {
             assertEquals("Cannot call queryParam() when this already has an unstructured query specified",
-                e.getMessage());
+                    e.getMessage());
         }
     }
 
@@ -353,27 +353,62 @@ public final class UrlBuilderTest {
         UrlBuilder ub = forHost("http", "foo.com").queryParam("foo", "bar");
 
         try {
-            ub.query("q");
+            ub.unstructuredQuery("q");
 
             fail();
         } catch (IllegalStateException e) {
-            assertEquals("Cannot call query() when this already has queryParam pairs specified", e.getMessage());
+            assertEquals("Cannot call unstructuredQuery() when this already has queryParam pairs specified",
+                    e.getMessage());
         }
     }
 
     @Test
     public void testUnstructuredQueryWithNoSpecialChars() throws CharacterCodingException {
-        assertUrlEquals("http://foo.com?q", forHost("http", "foo.com").query("q").toUrlString());
+        assertUrlEquals("http://foo.com?q", forHost("http", "foo.com").unstructuredQuery("q").toUrlString());
     }
 
     @Test
     public void testUnstructuredQueryWithOkSpecialChars() throws CharacterCodingException {
-        assertUrlEquals("http://foo.com?q?/&=+", forHost("http", "foo.com").query("q?/&=+").toUrlString());
+        assertUrlEquals("http://foo.com?q?/&=+", forHost("http", "foo.com").unstructuredQuery("q?/&=+").toUrlString());
     }
 
     @Test
     public void testUnstructuredQueryWithEscapedSpecialChars() throws CharacterCodingException {
-        assertUrlEquals("http://foo.com?q%23", forHost("http", "foo.com").query("q#").toUrlString());
+        assertUrlEquals("http://foo.com?q%23", forHost("http", "foo.com").unstructuredQuery("q#").toUrlString());
+    }
+
+    @Test
+    public void testClearQueryRemovesQueryParam() throws CharacterCodingException {
+        UrlBuilder ub = forHost("http", "host")
+                .queryParam("foo", "bar")
+                .clearQuery();
+        assertUrlEquals("http://host", ub.toUrlString());
+    }
+
+    @Test
+    public void testClearQueryRemovesUnstructuredQuery() throws CharacterCodingException {
+        UrlBuilder ub = forHost("http", "host")
+                .unstructuredQuery("foobar")
+                .clearQuery();
+        assertUrlEquals("http://host", ub.toUrlString());
+    }
+
+    @Test
+    public void testClearQueryAfterQueryParamAllowsQuery() throws CharacterCodingException {
+        UrlBuilder ub = forHost("http", "host")
+                .queryParam("foo", "bar")
+                .clearQuery()
+                .unstructuredQuery("foobar");
+        assertUrlEquals("http://host?foobar", ub.toUrlString());
+    }
+
+    @Test
+    public void testClearQueryAfterQueryAllowsQueryParam() throws CharacterCodingException {
+        UrlBuilder ub = forHost("http", "host")
+                .unstructuredQuery("foobar")
+                .clearQuery()
+                .queryParam("foo", "bar");
+        assertUrlEquals("http://host?foo=bar", ub.toUrlString());
     }
 
     private void assertUrlBuilderRoundtrip(String url) {

--- a/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
+++ b/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
@@ -369,12 +369,12 @@ public final class UrlBuilderTest {
 
     @Test
     public void testUnstructuredQueryWithOkSpecialChars() throws CharacterCodingException {
-        assertUrlEquals("http://foo.com?q?/&=+", forHost("http", "foo.com").unstructuredQuery("q?/&=+").toUrlString());
+        assertUrlEquals("http://foo.com?q?/&=", forHost("http", "foo.com").unstructuredQuery("q?/&=").toUrlString());
     }
 
     @Test
     public void testUnstructuredQueryWithEscapedSpecialChars() throws CharacterCodingException {
-        assertUrlEquals("http://foo.com?q%23", forHost("http", "foo.com").unstructuredQuery("q#").toUrlString());
+        assertUrlEquals("http://foo.com?q%23%2B", forHost("http", "foo.com").unstructuredQuery("q#+").toUrlString());
     }
 
     @Test

--- a/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
+++ b/src/test/java/com/palominolabs/http/url/UrlBuilderTest.java
@@ -331,8 +331,8 @@ public final class UrlBuilderTest {
     }
 
     @Test
-    public void testFromUrlUnstructuredQuery() throws MalformedURLException, CharacterCodingException {
-        assertUrlBuilderRoundtrip("http://foo.com/foo?query==&");
+    public void testFromUrlUnstructuredQueryWithEscapedChars() throws MalformedURLException, CharacterCodingException {
+        assertUrlBuilderRoundtrip("http://foo.com/foo?query==&%23");
     }
 
     @Test


### PR DESCRIPTION
query params are only part of the HTML form submission spec, not HTTP itself, so we should support arbitrary queries.